### PR TITLE
Dashboard#home update exchanges validated

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -4,7 +4,10 @@ class DashboardsController < ApplicationController
   before_action :set_current_user, only: [:home, :my_shifts, :my_answers]
 
   def home
-    @exchanges_validated = Exchange.joins(joins_sql_validated).where(where_sql_myshifts_validated, user_id: current_user.id)
+    @exchanges_validated_where_owner = Exchange.joins(joins_sql_validated_where_owner).where(where_sql_myshifts_validated, user_id: current_user.id)
+    @exchanges_validated_where_answer = Exchange.joins(joins_sql_validated_where_answer).where(where_sql_myshifts_validated, user_id: current_user.id)
+    @exchanges_validated = @exchanges_validated_where_answer + @exchanges_validated_where_owner
+
     @lines = Line.all
     @shifts = Shift.joins(joins_sql)
                    .where(where_sql, user_id: current_user.id, unit_id: current_user.unit_id, date: Date.today)
@@ -40,7 +43,6 @@ class DashboardsController < ApplicationController
         @shifts_and_answers["#{exchange.shift_owner_id}"] <<  { exchange.shift_answer_id => exchange.id } # pour integrer instance plutot que id : Shift.find(exchange.shift_answer_id)
       end
     end
-    # HISTORIQUE DES ECHANGES ACCEPTES
   end
 
   def my_answers
@@ -88,9 +90,16 @@ class DashboardsController < ApplicationController
     SQL
   end
 
-    def joins_sql_validated
+  def joins_sql_validated_where_owner
     <<~SQL
-      INNER JOIN shifts ON shifts.id = exchanges.shift_owner_id OR shifts.id = exchanges.shift_answer_id
+      INNER JOIN shifts ON shifts.id = exchanges.shift_owner_id
+      INNER JOIN users ON users.id = shifts.user_id
+    SQL
+  end
+
+  def joins_sql_validated_where_answer
+    <<~SQL
+      INNER JOIN shifts ON shifts.id = exchanges.shift_answer_id
       INNER JOIN users ON users.id = shifts.user_id
     SQL
   end
@@ -129,7 +138,6 @@ class DashboardsController < ApplicationController
   def where_sql_myshifts_shifts_owner
     <<~SQL
       users.id = :user_id AND
-      exchanges.shift_owner_id = shifts.id AND
       exchange_accepted_level_one IS NULL
     SQL
   end

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -4,7 +4,7 @@ class DashboardsController < ApplicationController
   before_action :set_current_user, only: [:home, :my_shifts, :my_answers]
 
   def home
-    @exchanges_validated = Exchange.joins(joins_sql_myshifts).where(where_sql_myshifts_validated, user_id: current_user.id)
+    @exchanges_validated = Exchange.joins(joins_sql_validated).where(where_sql_myshifts_validated, user_id: current_user.id)
     @lines = Line.all
     @shifts = Shift.joins(joins_sql)
                    .where(where_sql, user_id: current_user.id, unit_id: current_user.unit_id, date: Date.today)
@@ -84,6 +84,13 @@ class DashboardsController < ApplicationController
   def joins_sql_myshifts
     <<~SQL
       INNER JOIN shifts ON shifts.id = exchanges.shift_owner_id
+      INNER JOIN users ON users.id = shifts.user_id
+    SQL
+  end
+
+    def joins_sql_validated
+    <<~SQL
+      INNER JOIN shifts ON shifts.id = exchanges.shift_owner_id OR shifts.id = exchanges.shift_answer_id
       INNER JOIN users ON users.id = shifts.user_id
     SQL
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_25_123437) do
+ActiveRecord::Schema.define(version: 2020_06_25_153141) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -71,6 +71,7 @@ ActiveRecord::Schema.define(version: 2020_06_25_123437) do
     t.bigint "unit_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "image"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["unit_id"], name: "index_users_on_unit_id"


### PR DESCRIPTION
Decomposition de la data exchanges_validated en deux parties :
 - exchanges_validated_where_owner: array d'echanges acceptés dont l'utilisation est owner
 - exchanges_validated_where_answer: array d'echanges acceptés dont l'utilisation est answer
Intégration des deux types dans la variable d'instance @exchanges_validated pour affichage dans le dashboard 